### PR TITLE
Füge Navigation zur Kundenanlegen-Ansicht hinzu

### DIFF
--- a/AppShell.xaml
+++ b/AppShell.xaml
@@ -3,7 +3,8 @@
     x:Class="RechnungenPrivat.AppShell"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:local="clr-namespace:RechnungenPrivat"
+    xmlns:local="clr-namespace:RechnungenPrivat.Views.Startseite"
+    xmlns:KundeAnlegen="clr-namespace:RechnungenPrivat.Views.KundenAnlegen"   
     Shell.FlyoutBehavior="Flyout"
     Title="RechnungenPrivat">
 
@@ -11,5 +12,11 @@
         Title="Home"
         ContentTemplate="{DataTemplate local:MainPage}"
         Route="MainPage" />
+
+    <ShellContent
+        Title="Kundenanlegen"
+        ContentTemplate="{DataTemplate KundeAnlegen:KundenAnlegenView}"
+        />
+    
 
 </Shell>

--- a/AppShell.xaml.cs
+++ b/AppShell.xaml.cs
@@ -1,10 +1,13 @@
-﻿namespace RechnungenPrivat
+﻿using RechnungenPrivat.Views.KundenAnlegen;
+
+namespace RechnungenPrivat
 {
     public partial class AppShell : Shell
     {
         public AppShell()
         {
             InitializeComponent();
+            Routing.RegisterRoute(nameof(KundenAnlegenView), typeof(KundenAnlegenView));
         }
     }
 }

--- a/Data/Interfaces/INavigationService.cs
+++ b/Data/Interfaces/INavigationService.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RechnungenPrivat.Data.Interfaces
+{
+    public interface INavigationService
+    {
+
+        Task NavigateToAsync(string route);
+        Task NavigateToAsync<T>(string route, IDictionary<string,object> parameters);
+        Task GoBackAsync();
+
+    }
+}

--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -1,4 +1,8 @@
 ﻿using Microsoft.Extensions.Logging;
+using RechnungenPrivat.Data.Interfaces;
+using RechnungenPrivat.Navigation;
+using RechnungenPrivat.ViewModels.Startseite;
+using RechnungenPrivat.Views.Startseite;
 
 namespace RechnungenPrivat;
 
@@ -14,9 +18,11 @@ public static class MauiProgram
 				fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
 				fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
 			});
-
+		builder.Services.AddSingleton<INavigationService,MauiNavigationService>();
+		builder.Services.AddTransient<MainPageViewModel>();
+        builder.Services.AddTransient<MainPage>();
 #if DEBUG
-		builder.Logging.AddDebug();
+        builder.Logging.AddDebug();
 #endif
 
 		return builder.Build();

--- a/Models/Kunde.cs
+++ b/Models/Kunde.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using SQLite;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -6,10 +7,14 @@ using System.Threading.Tasks;
 
 namespace RechnungenPrivat.Models
 {
+    [Table("Kunde")]
     public class Kunde
     {
+        [PrimaryKey, AutoIncrement]
         public int Id { get; set; }
+        [MaxLength(100)]
         public string Kundenname { get; set; }
+        [MaxLength(100)]
         public string KundenAdresse { get; set; }
     }
 }

--- a/Navigation/MauiNavigationService.cs
+++ b/Navigation/MauiNavigationService.cs
@@ -1,0 +1,29 @@
+﻿using RechnungenPrivat.Data.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RechnungenPrivat.Navigation
+{
+    class MauiNavigationService : INavigationService
+    {
+        public Task NavigateToAsync(string route)
+        {
+            return Shell.Current.GoToAsync(route);
+        }
+
+        public Task NavigateToAsync<T>(string route, IDictionary<string, object> parameters)
+        { 
+            return Shell.Current.GoToAsync(route, parameters);
+        }
+
+        public Task GoBackAsync()
+        {
+            return Shell.Current.GoToAsync("..");
+        }
+    }   
+    
+}
+

--- a/RechnungenPrivat.csproj
+++ b/RechnungenPrivat.csproj
@@ -60,12 +60,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.0" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <Folder Include="Data\Interfaces\" />
+		<PackageReference Include="sqlite-net-pcl" Version="1.9.172" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/ViewModels/Startseite/MainPageViewModel.cs
+++ b/ViewModels/Startseite/MainPageViewModel.cs
@@ -1,0 +1,29 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using RechnungenPrivat.Data.Interfaces;
+using RechnungenPrivat.Views.KundenAnlegen;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RechnungenPrivat.ViewModels.Startseite
+{
+    public partial class MainPageViewModel : ObservableObject
+    {
+        private readonly INavigationService _navigationService;
+
+        public MainPageViewModel(INavigationService navigationService)
+        {
+            _navigationService = navigationService;
+        }
+
+        [RelayCommand]
+        public async Task GoToKundenAnlegen()
+        {
+            var route = $"{nameof(KundenAnlegenView)}";
+            await _navigationService.NavigateToAsync(route);
+        }
+    }
+}

--- a/Views/Startseite/MainPage.xaml
+++ b/Views/Startseite/MainPage.xaml
@@ -1,7 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="RechnungenPrivat.MainPage">
+             x:Class="RechnungenPrivat.Views.Startseite.MainPage"
+             xmlns:vm="clr-namespace:RechnungenPrivat.ViewModels.Startseite"
+             x:DataType="vm:MainPageViewModel">
+            
 
     <ScrollView>
         <VerticalStackLayout
@@ -25,11 +28,9 @@
                 SemanticProperties.Description="Welcome to dot net Multi platform App U I" />
 
             <Button
-                x:Name="CounterBtn"
-                Text="Click me" 
-                SemanticProperties.Hint="Counts the number of times you click"
-                Clicked="OnCounterClicked"
-                HorizontalOptions="Fill" />
+                Text="Got To Kundenanlegen"
+                Command="{Binding GoToKundenAnlegenCommand}"
+                />
         </VerticalStackLayout>
     </ScrollView>
 

--- a/Views/Startseite/MainPage.xaml.cs
+++ b/Views/Startseite/MainPage.xaml.cs
@@ -1,25 +1,18 @@
-﻿namespace RechnungenPrivat
+﻿using RechnungenPrivat.ViewModels.Startseite;
+
+namespace RechnungenPrivat.Views.Startseite
 {
+
+
     public partial class MainPage : ContentPage
     {
-        int count = 0;
 
-        public MainPage()
+        public MainPage(MainPageViewModel mainPageViewModel)
         {
             InitializeComponent();
+            BindingContext = mainPageViewModel;
         }
 
-        private void OnCounterClicked(object sender, EventArgs e)
-        {
-            count++;
-
-            if (count == 1)
-                CounterBtn.Text = $"Clicked {count} time";
-            else
-                CounterBtn.Text = $"Clicked {count} times";
-
-            SemanticScreenReader.Announce(CounterBtn.Text);
-        }
     }
 
 }


### PR DESCRIPTION
Füge Navigation zur Kundenanlegen-Ansicht hinzu

- Neuer `ShellContent` für `KundenAnlegenView` in `AppShell.xaml`.
- Registrierung der Route für `KundenAnlegenView` in `AppShell.xaml.cs`.
- Erstellung des `INavigationService` Interfaces zur Navigation.
- Aktualisierung von `MauiProgram.cs` zur Registrierung des `INavigationService`.
- Einführung der `Kunde` Klasse in `Kunde.cs` für die Datenbank.
- Implementierung des `INavigationService` in `MauiNavigationService.cs`.
- Hinzufügen neuer NuGet-Pakete in `RechnungenPrivat.csproj`.
- Erstellung des `MainPageViewModel` zur Navigation von `MainPage`.
- Anpassung von `MainPage.xaml` zur Verwendung des ViewModels.
- Aktualisierung des Konstruktors in `MainPage.xaml.cs` und Entfernung der Zähler-Logik.